### PR TITLE
allow specifying schema on commandline

### DIFF
--- a/examples/AliPay/Dropoff/Makefile
+++ b/examples/AliPay/Dropoff/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/AliPay/Hotel/Makefile
+++ b/examples/AliPay/Hotel/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/AliPay/Invitation/Makefile
+++ b/examples/AliPay/Invitation/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/AliPay/Pickup/Makefile
+++ b/examples/AliPay/Pickup/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/AliPay/Summit/Makefile
+++ b/examples/AliPay/Summit/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/AliPay/Tour Package A/Makefile
+++ b/examples/AliPay/Tour Package A/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/AliPay/Tour Package B/Makefile
+++ b/examples/AliPay/Tour Package B/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/EntryToken/Makefile
+++ b/examples/EntryToken/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/Sports/Makefile
+++ b/examples/Sports/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/TicketTemplate/Makefile
+++ b/examples/TicketTemplate/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/UEFA/Makefile
+++ b/examples/UEFA/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/action/Makefile
+++ b/examples/action/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/devcon5-nft/Makefile
+++ b/examples/devcon5-nft/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/edcon/Makefile
+++ b/examples/edcon/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/erc20/AlphaWallet-Discovery-Token/Makefile
+++ b/examples/erc20/AlphaWallet-Discovery-Token/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/erc20/DAI/Makefile
+++ b/examples/erc20/DAI/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/erc20/DeFi/Makefile
+++ b/examples/erc20/DeFi/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/erc20/SAI/Makefile
+++ b/examples/erc20/SAI/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/erc20/WETH/Makefile
+++ b/examples/erc20/WETH/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if INVALID, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (mv $@ $@.INVALID; xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@.INVALID)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (mv $@ $@.INVALID; xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@.INVALID)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))

--- a/examples/fifa/Makefile
+++ b/examples/fifa/Makefile
@@ -1,3 +1,6 @@
+ifeq ($(TOKENSCRIPT_SCHEMA),)
+TOKENSCRIPT_SCHEMA=http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd
+endif
 XMLSECTOOL=xmlsectool
 KEYSTORE=
 KEY=1
@@ -23,7 +26,7 @@ help:
 	# XML Validation
     # if failed, run validation again with xmllint to get meaningful error
     # then delete the canonicalized file
-	-xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@ || (xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd $@; rm $@)
+	-xmlstarlet val --xsd $(TOKENSCRIPT_SCHEMA) $@ || (xmllint --noout --schema $(TOKENSCRIPT_SCHEMA) $@; rm $@)
 
 %.tsml: %.canonicalized.xml
 ifeq (,$(KEYSTORE))


### PR DESCRIPTION
Before, you can do this:
````
fifa$ make fifa.canonicalized.xml
# XML Canonicalization
xmlstarlet c14n fifa.xml  > fifa.canonicalized.xml
# XML Validation
xmlstarlet val --xsd http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd fifa.canonicalized.xml || (xmllint --noout --schema http://tokenscript.org/2019/10/tokenscript/tokenscript.xsd fifa.canonicalized.xml; rm fifa.canonicalized.xml)
fifa.canonicalized.xml - valid
````
now, on top of that, you can do this too:
````
fifa$ TOKENSCRIPT_SCHEMA=../../../TokenScript/schema/tokenscript.xsd make fifa.canonicalized.xml
# XML Canonicalization
xmlstarlet c14n fifa.xml  > fifa.canonicalized.xml
# XML Validation
xmlstarlet val --xsd ../../../TokenScript/schema/tokenscript.xsd fifa.canonicalized.xml || (xmllint --noout --schema ../../../TokenScript/schema/tokenscript.xsd fifa.canonicalized.xml; rm fifa.canonicalized.xml)
fifa.canonicalized.xml - invalid
../../../TokenScript/schema/xhtml1-strict.xsd:33: element import: Schemas parser warning : Element '{http://www.w3.org/2001/XMLSchema}import': Skipping import of schema located at 'http://www.w3.org/2001/xml.xsd' for the namespace 'http://www.w3.org/XML/1998/namespace', since this namespace was already imported with the schema located at '../../../TokenScript/schema/xml.xsd'.
fifa.canonicalized.xml:28: element token-card: Schemas validity error : Element '{http://tokenscript.org/2019/10/tokenscript}token-card': This element is not expected. Expected is one of ( {http://tokenscript.org/2019/10/tokenscript}token, {http://tokenscript.org/2019/10/tokenscript}action, {http://tokenscript.org/2019/10/tokenscript}event ).
fifa.canonicalized.xml fails to validate
````

This flexibility is important for testing new schema without modifying Makefiles
