### PR TITLE
adding a group validation 

### DIFF
--- a/examples/validate.sh
+++ b/examples/validate.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]; then
+	echo Usage:
+	echo '	$ ./validate.sh directory/filename.xml'
+	echo which validates the said XML file - a TokenScript file
+	echo '	'
+	echo You can do a blanket test of all xml files by:
+	echo '	$ ./validate.sh */*.xml */*/*.xml'
+	echo '	'
+	echo 'You can specify a schema file (with absolute path)'
+	echo '	$ TOKENSCRIPT_SCHEMA=/home/james/TokenScript-Repo/www/2019/10/tokenscript/tokenscript.xsd  ./validate.sh */*.xml */*/*.xml'
+fi
+
+CWD=${PWD}
+for i in "$@"
+do
+	# ignore all folders with space in it
+	echo "$i" | grep ' '  && continue
+
+	if [ -f "${i%.xml}.canonicalized.xml" ]; then
+	    rm  "${i%.xml}.canonicalized.xml"
+	fi
+
+	BN=`basename "$i" .xml`
+
+	cd "${i%/*.xml}"
+
+	make "${BN}.canonicalized.xml" > /dev/null && echo "[Valid] : $i"
+
+	cd $CWD
+	## the following is very important to prevent these XML files being picked up in the next run
+	if [ -f "${i%.xml}.canonicalized.xml" ]; then
+	    rm  "${i%.xml}.canonicalized.xml"
+	fi
+done;


### PR DESCRIPTION
The idea is to test all examples at once. This is my run on my computer (do it under example directory)

````
example $ TOKENSCRIPT_SCHEMA=/home/weiwu/IdeaProjects/TokenScript-Repo/www/2019/10/tokenscript/tokenscript.xsd ./validate.sh */*.xml */*/*.xml
[Valid] : action/XDAI-bridge.xml
[Valid] : devcon5-nft/Devcon.xml
[Valid] : edcon/unicon.xml
[Valid] : EntryToken/EntryToken.xml
[Valid] : fifa/fifa.xml
[Valid] : Sports/sports.xml
[Valid] : TicketTemplate/TicketTemplate.xml
[Valid] : UEFA/UEFA.xml
[Valid] : AliPay/Dropoff/Dropoff.xml
[Valid] : AliPay/Hotel/Hotel.xml
[Valid] : AliPay/Invitation/Invitation.xml
[Valid] : AliPay/Pickup/Pickup.xml
[Valid] : AliPay/Summit/Summit.xml
AliPay/Tour Package A/TourA.xml
AliPay/Tour Package B/TourB.xml
[Valid] : erc20/AlphaWallet-Discovery-Token/ALP.xml
[Valid] : erc20/DAI/DAI.xml
[Valid] : erc20/SAI/SAI.xml
[Valid] : erc20/WETH/WETH.xml

````

The script is suitable for a travis job @James-Sangalli @jzaki 