### PR TITLE
Fix: TokenScript file for ENS' events should filter against the owner Ethereum address

### DIFF
--- a/examples/ENS/ENS.xml
+++ b/examples/ENS/ENS.xml
@@ -139,7 +139,7 @@
 
     <ts:attribute-type id="ensName" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <ts:origins>
-        <ts:ethereum event="EventRegistered" filter="label=${tokenId}" select="name"/>
+        <ts:ethereum event="EventRegistered" filter="owner=${ownerAddress}" select="name"/>
       </ts:origins>
     </ts:attribute-type>
 


### PR DESCRIPTION
Since we are only interested in events concerning the user's wallet.