### PR TITLE
Fix: should refer to `NameRegistered` instead of `EventRegistered` as the source for attribute for ENS TokenScript

### DIFF
--- a/examples/ENS/ENS.xml
+++ b/examples/ENS/ENS.xml
@@ -139,7 +139,7 @@
 
     <ts:attribute-type id="ensName" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <ts:origins>
-        <ts:ethereum event="EventRegistered" filter="label=${tokenId}" select="name"/>
+        <ts:ethereum event="NameRegistered" filter="label=${tokenId}" select="name"/>
       </ts:origins>
     </ts:attribute-type>
 


### PR DESCRIPTION
Sorry, missed this when reviewing #27

cc @JamesSmartCell 