### PR TITLE
updating all tokenscript examples following the schema branch ethereum-namespace

### DIFF
--- a/examples/ENS/ENS.xml
+++ b/examples/ENS/ENS.xml
@@ -43,8 +43,7 @@
   </ts:contract>
   <ts:origins>
     <!-- Define the contract which holds the token that the user will use -->
-    <ts:ethereum contract="ENS">
-    </ts:ethereum>
+    <ts:ethereum contract="ENS"/>
   </ts:origins>
 
   <ts:cards>
@@ -65,23 +64,23 @@
 
       <ts:attribute-type id="emailRecord" syntax="1.3.6.1.4.1.1466.115.121.1.15">
         <ts:origins>
-          <ts:ethereum as="utf8" contract="PublicResolver" function="text">
+          <ethereum:call as="utf8" contract="PublicResolver" function="text">
             <ts:data>
               <ts:bytes32 local-ref="nodeHash"/>
               <ts:string>email</ts:string>
             </ts:data>
-          </ts:ethereum>
+          </ethereum:call>
         </ts:origins>
       </ts:attribute-type>
 
       <ts:transaction>
-        <ts:ethereum function="setText" contract="PublicResolver" as="bool">
+        <ethereum:call function="setText" contract="PublicResolver" as="bool">
           <ts:data>
             <ts:bytes32 local-ref="nodeHash"/>
             <ts:string>email</ts:string>
             <ts:string ref="value"/>
           </ts:data>
-        </ts:ethereum>
+        </ethereum:call>
       </ts:transaction>
 
       <ts:view xml:lang="en">
@@ -101,23 +100,23 @@
           <ts:string xml:lang="en">renewal price per year</ts:string>
         </ts:name>
         <ts:origins>
-          <ts:ethereum function="rentPrice" contract="ETHRegistrarController" as="uint">
+          <ethereum:call function="rentPrice" contract="ETHRegistrarController" as="uint">
             <ts:data>
               <ts:string ref="ensName"/>
               <ts:uint256>31556952</ts:uint256>
             </ts:data>
-          </ts:ethereum>
+          </ethereum:call>
         </ts:origins>
       </ts:attribute-type>
 
       <ts:transaction>
-        <ts:ethereum function="renew" contract="ETHRegistrarController" as="uint">
-          <ts:value ref="renewalPricePerYear"/>
+        <ethereum:call function="renew" contract="ETHRegistrarController" as="uint">
+          <ethereum:ether ref="renewalPricePerYear"/>
           <ts:data>
             <ts:string ref="ensName"/>
             <ts:uint256>31556952</ts:uint256>
           </ts:data>
-        </ts:ethereum>
+        </ethereum:call>
       </ts:transaction>
       <ts:view xml:lang="en">
         <xhtml:style type="text/css">&style;</xhtml:style>
@@ -129,17 +128,17 @@
 
   <ts:attribute-type id="ensName" syntax="1.3.6.1.4.1.1466.115.121.1.15">
     <ts:origins>
-      <ts:ethereum event="NameRegistered" filter="label=${tokenId}" select="name"/>
+      <ethereum:event module="NameRegistered" filter="label=${tokenId}" select="name"/>
     </ts:origins>
   </ts:attribute-type>
 
   <ts:attribute-type id="nameExpires" syntax="1.3.6.1.4.1.1466.115.121.1.36">
     <ts:origins>
-      <ts:ethereum function="nameExpires" contract="ENS" as="uint">
+      <ethereum:call function="nameExpires" contract="ENS" as="uint">
         <ts:data>
           <ts:uint256 ref="tokenId"/>
         </ts:data>
-      </ts:ethereum>
+      </ethereum:call>
     </ts:origins>
   </ts:attribute-type>
 

--- a/examples/EntryToken/EntryToken.xml
+++ b/examples/EntryToken/EntryToken.xml
@@ -7,6 +7,7 @@
     <!ENTITY style SYSTEM "shared.css">
 ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -33,8 +34,7 @@
   </ts:contract>
   <ts:origins>
     <!-- Define the contract which holds the token that the user will use -->
-    <ts:ethereum contract="EntryToken">
-    </ts:ethereum>
+    <ts:ethereum contract="EntryToken"/>
   </ts:origins>
     <ts:selection id="expired" filter="expired=TRUE">
       <ts:name>
@@ -77,11 +77,11 @@
   </ts:cards>
     <ts:attribute-type id="locality" syntax="1.3.6.1.4.1.1466.115.121.1.15">
       <ts:origins>
-        <ts:ethereum function="getLocality" contract="EntryToken" as="utf8">
+        <ethereum:call function="getLocality" contract="EntryToken" as="utf8">
             <ts:data>
               <ts:uint256 ref="tokenId"/>
             </ts:data>
-        </ts:ethereum>
+        </ethereum:call>
       </ts:origins>
 
     </ts:attribute-type>
@@ -96,38 +96,38 @@
     </ts:attribute-type>
     <ts:attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7"> <!-- boolean -->
       <ts:origins>
-        <ts:ethereum function="isExpired" contract="EntryToken" as="bool">
+        <ethereum:call function="isExpired" contract="EntryToken" as="bool">
           <ts:data>
             <ts:uint256 ref="tokenId"/>
           </ts:data>
-        </ts:ethereum>
+        </ethereum:call>
       </ts:origins>
     </ts:attribute-type>
     <ts:attribute-type id="street" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
       <ts:origins>
-        <ts:ethereum function="getStreet" contract="EntryToken" as="utf8">
+        <ethereum:call function="getStreet" contract="EntryToken" as="utf8">
           <ts:data>
             <ts:uint256 ref="tokenId"/>
           </ts:data>
-        </ts:ethereum>
+        </ethereum:call>
       </ts:origins>
     </ts:attribute-type>
     <ts:attribute-type id="building" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
       <ts:origins>
-        <ts:ethereum function="getBuildingName" contract="EntryToken" as="utf8">
+        <ethereum:call function="getBuildingName" contract="EntryToken" as="utf8">
           <ts:data>
             <ts:uint256 ref="tokenId"/>
           </ts:data>
-        </ts:ethereum>
+        </ethereum:call>
       </ts:origins>
     </ts:attribute-type>
     <ts:attribute-type id="state" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
       <ts:origins>
-        <ts:ethereum function="getState" contract="EntryToken" as="utf8">
+        <ethereum:call function="getState" contract="EntryToken" as="utf8">
           <ts:data>
             <ts:uint256 ref="tokenId"/>
           </ts:data>
-        </ts:ethereum>
+        </ethereum:call>
       </ts:origins>
     </ts:attribute-type>
 </ts:token>

--- a/examples/Karma/karma.xml
+++ b/examples/Karma/karma.xml
@@ -7,6 +7,7 @@
         <!ENTITY item-view.en SYSTEM "item-view.en.shtml">
 ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -33,8 +34,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="CarToken">
-        </ts:ethereum>
+        <ts:ethereum contract="CarToken"/>
     </ts:origins>
     <ts:cards>
         <ts:token>
@@ -84,11 +84,11 @@
     </ts:cards>
         <ts:attribute-type id="locality" syntax="1.3.6.1.4.1.1466.115.121.1.15">
             <ts:origins>
-                <ts:ethereum as="utf8" contract="CarToken" function="getLocality">
+                <ethereum:call function="getLocality" as="utf8" contract="CarToken">
                     <ts:data>
                         <ts:uint256 ref="tokenId"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
 
         </ts:attribute-type>
@@ -103,38 +103,38 @@
         </ts:attribute-type>
         <ts:attribute-type id="expired" syntax="1.3.6.1.4.1.1466.115.121.1.7"> <!-- boolean -->
             <ts:origins>
-                <ts:ethereum as="bool" contract="CarToken" function="isExpired">
+                <ethereum:call function="isExpired" as="bool" contract="CarToken">
                     <ts:data>
                         <ts:uint256 ref="tokenId"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
         <ts:attribute-type id="model" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
             <ts:origins>
-                <ts:ethereum as="utf8" contract="CarToken" function="getStreet">
+                <ethereum:call function="getStreet" as="utf8" contract="CarToken">
                     <ts:data>
                         <ts:uint256 ref="tokenId"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
         <ts:attribute-type id="VIN" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
             <ts:origins>
-                <ts:ethereum as="utf8" contract="CarToken" function="getBuildingName">
+                <ethereum:call function="getBuildingName" as="utf8" contract="CarToken">
                     <ts:data>
                         <ts:uint256 ref="tokenId"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
         <ts:attribute-type id="state" syntax="1.3.6.1.4.1.1466.115.121.1.15"> <!-- string -->
             <ts:origins>
-                <ts:ethereum as="utf8" contract="CarToken" function="getState">
+                <ethereum:call function="getState" as="utf8" contract="CarToken">
                     <ts:data>
                         <ts:uint256 ref="tokenId"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/UEFA/UEFA.xml
+++ b/examples/UEFA/UEFA.xml
@@ -5,6 +5,7 @@
         <!ENTITY style SYSTEM "shared.css">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -30,8 +31,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="UEFA">
-        </ts:ethereum>
+        <ts:ethereum contract="UEFA"/>
     </ts:origins>
 
     <ts:cards>
@@ -266,11 +266,11 @@
                 <ts:string xml:lang="en">Redeemed</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="redeemed" contract="UEFA" as="bool">
+                <ethereum:call function="redeemed" contract="UEFA" as="bool">
                     <ts:data>
                         <ts:uint256 ref="tokenId"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 

--- a/examples/action/XDAI-bridge.xml
+++ b/examples/action/XDAI-bridge.xml
@@ -4,6 +4,7 @@
         <!ENTITY xdai-bridge.en SYSTEM "xdai-bridge.en.js">
 ]>
 <ts:action xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -59,10 +60,10 @@
          exclude="low_balance" to the root element.
     -->
     <ts:transaction>
-        <ts:ethereum>
-            <ts:to>0x7301CFA0e1756B71869E93d4e4Dca5c7d0eb0AA6</ts:to>
-            <ts:value ref="amount"/>
-        </ts:ethereum>
+        <ethereum:transfer>
+            <ethereum:to>0x7301CFA0e1756B71869E93d4e4Dca5c7d0eb0AA6</ethereum:to>
+            <ethereum:ether ref="amount"/>
+        </ethereum:transfer>
     </ts:transaction>
     <ts:view xml:lang="en" xmlns="http://www.w3.org/1999/xhtml">
         <style type="text/css">&style;</style>

--- a/examples/edcon/unicon.xml
+++ b/examples/edcon/unicon.xml
@@ -4,6 +4,7 @@
         <!ENTITY style SYSTEM "shared.css">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -23,8 +24,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="unicon">
-        </ts:ethereum>
+        <ts:ethereum contract="unicon"/>
     </ts:origins>
 
     <ts:cards>
@@ -125,11 +125,11 @@
                 <ts:string>Redeemed</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="redeemed" contract="unicon" as="bool">
+                <ethereum:call function="redeemed" contract="unicon" as="bool">
                     <ts:data>
                         <ts:uint256 ref="tokenId"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 

--- a/examples/erc20/AAVE/aDAI.xml
+++ b/examples/erc20/AAVE/aDAI.xml
@@ -47,12 +47,12 @@
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:name>
             <ts:transaction>
-                <ts:ethereum function="approve" contract="DAI" as="bool">
+                <ethereum:call function="approve" contract="DAI" as="bool">
                     <ts:data>
                         <ts:address>0xfC1E690f61EFd961294b3e1Ce3313fBD8aa4f85d</ts:address>
                         <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -75,13 +75,13 @@
 <!--                </ts:origins>-->
 <!--            </ts:attribute-type>-->
 <!--            <ts:transaction>-->
-<!--                <ts:ethereum function="deposit" contract="lendingPoolAddress" as="uint">-->
+<!--                <ethereum:call function="deposit" contract="lendingPoolAddress" as="uint">-->
 <!--                    <ts:data>-->
 <!--                        <ts:address>0x6B175474E89094C44Da98b954EedeAC495271d0F</ts:address>-->
 <!--                        <ts:uint256 ref="mintAmount"/>-->
 <!--                        <ts:uint256>1101</ts:uint256> &lt;!&ndash; placeholder referral &ndash;&gt;-->
 <!--                    </ts:data>-->
-<!--                </ts:ethereum>-->
+<!--                </ethereum:call>-->
 <!--            </ts:transaction>-->
 <!--            <style type="text/css">&style;</style>-->
 <!--            <ts:view xml:lang="en">&supply.en;</ts:view>-->
@@ -100,11 +100,11 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="redeem" contract="aDAI" as="uint">
+                <ethereum:call function="redeem" contract="aDAI" as="uint">
                     <ts:data>
                         <ts:uint256 ref="redeemAmount"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -116,19 +116,19 @@
 
     <ts:attribute-type id="lendingPoolAddress" syntax="1.3.6.1.4.1.1466.115.121.1.15">
         <ts:origins>
-            <ts:ethereum function="getLendingPool" contract="LendingPoolAddressesProvider" as="address">
-            </ts:ethereum>
+            <ethereum:call function="getLendingPool" contract="LendingPoolAddressesProvider" as="address">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
     <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
         <ts:origins>
-            <ts:ethereum function="allowance" contract="DAI" as="uint">
+            <ethereum:call function="allowance" contract="DAI" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                     <ts:address>0xfC1E690f61EFd961294b3e1Ce3313fBD8aa4f85d</ts:address>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -139,11 +139,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="DAI" as="uint">
+            <ethereum:call function="balanceOf" contract="DAI" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -153,11 +153,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="aDAI" as="uint">
+            <ethereum:call function="balanceOf" contract="aDAI" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -167,11 +167,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="principalBalanceOf" contract="aDAI" as="uint">
+            <ethereum:call function="principalBalanceOf" contract="aDAI" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 

--- a/examples/erc20/Compound/cBAT.xml
+++ b/examples/erc20/Compound/cBAT.xml
@@ -6,6 +6,7 @@
         <!ENTITY enable.en SYSTEM "enable.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -41,12 +42,12 @@
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:name>
         <ts:transaction>
-            <ts:ethereum function="approve" contract="BAT" as="bool">
+            <ethereum:call function="approve" contract="BAT" as="bool">
                 <ts:data>
                     <ts:address>0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E</ts:address>
                     <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -69,11 +70,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="mint" contract="cBAT" as="uint">
+            <ethereum:call function="mint" contract="cBAT" as="uint">
                 <ts:data>
                     <ts:uint256 ref="mintAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -94,11 +95,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="redeem" contract="cBAT" as="uint">
+            <ethereum:call function="redeem" contract="cBAT" as="uint">
                 <ts:data>
                     <ts:uint256 ref="redeemAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -110,12 +111,12 @@
 
     <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
         <ts:origins>
-            <ts:ethereum function="allowance" contract="BAT" as="uint">
+            <ethereum:call function="allowance" contract="BAT" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                     <ts:address>0x6C8c6b02E7b2BE14d4fA6022Dfd6d75921D90E4E</ts:address>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -126,11 +127,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="BAT" as="uint">
+            <ethereum:call function="balanceOf" contract="BAT" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -140,8 +141,8 @@
             <ts:string xml:lang="en">Exchange Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="exchangeRateCurrent" contract="cBAT" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="exchangeRateCurrent" contract="cBAT" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -151,11 +152,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="cBAT" as="uint">
+            <ethereum:call function="balanceOf" contract="cBAT" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -164,8 +165,8 @@
             <ts:string xml:lang="en">Supply Interest Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="supplyRatePerBlock" contract="cBAT" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="supplyRatePerBlock" contract="cBAT" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 

--- a/examples/erc20/Compound/cDAI.xml
+++ b/examples/erc20/Compound/cDAI.xml
@@ -6,6 +6,7 @@
         <!ENTITY enable.en SYSTEM "enable.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -41,12 +42,12 @@
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:name>
             <ts:transaction>
-                <ts:ethereum function="approve" contract="DAI" as="bool">
+                <ethereum:call function="approve" contract="DAI" as="bool">
                     <ts:data>
                         <ts:address>0x5d3a536e4d6dbd6114cc1ead35777bab948e3643</ts:address>
                         <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -69,11 +70,11 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="mint" contract="cDAI" as="uint">
+                <ethereum:call function="mint" contract="cDAI" as="uint">
                     <ts:data>
                         <ts:uint256 ref="mintAmount"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -94,11 +95,11 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="redeem" contract="cDAI" as="uint">
+                <ethereum:call function="redeem" contract="cDAI" as="uint">
                     <ts:data>
                         <ts:uint256 ref="redeemAmount"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -110,12 +111,12 @@
 
     <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
         <ts:origins>
-            <ts:ethereum function="allowance" contract="DAI" as="uint">
+            <ethereum:call function="allowance" contract="DAI" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                     <ts:address>0x5d3a536e4d6dbd6114cc1ead35777bab948e3643</ts:address>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -126,11 +127,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="DAI" as="uint">
+            <ethereum:call function="balanceOf" contract="DAI" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -140,8 +141,8 @@
             <ts:string xml:lang="en">Exchange Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="exchangeRateCurrent" contract="cDAI" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="exchangeRateCurrent" contract="cDAI" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -151,11 +152,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="cDAI" as="uint">
+            <ethereum:call function="balanceOf" contract="cDAI" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -164,8 +165,8 @@
             <ts:string xml:lang="en">Supply Interest Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="supplyRatePerBlock" contract="cDAI" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="supplyRatePerBlock" contract="cDAI" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 

--- a/examples/erc20/Compound/cETH.xml
+++ b/examples/erc20/Compound/cETH.xml
@@ -5,6 +5,7 @@
         <!ENTITY redeem.en SYSTEM "withdraw.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -37,11 +38,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="mint" contract="cETH" as="uint">
+            <ethereum:call function="mint" contract="cETH" as="uint">
                 <ts:data>
                     <ts:uint256 ref="mintAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -62,11 +63,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="redeem" contract="cETH" as="uint">
+            <ethereum:call function="redeem" contract="cETH" as="uint">
                 <ts:data>
                     <ts:uint256 ref="redeemAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -83,8 +84,8 @@
             <ts:string xml:lang="en">Exchange Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="exchangeRateCurrent" contract="cETH" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="exchangeRateCurrent" contract="cETH" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -94,11 +95,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="cETH" as="uint">
+            <ethereum:call function="balanceOf" contract="cETH" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -107,8 +108,8 @@
             <ts:string xml:lang="en">Supply Interest Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="supplyRatePerBlock" contract="cETH" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="supplyRatePerBlock" contract="cETH" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 

--- a/examples/erc20/Compound/cREP.xml
+++ b/examples/erc20/Compound/cREP.xml
@@ -6,6 +6,7 @@
         <!ENTITY enable.en SYSTEM "enable.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -41,12 +42,12 @@
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:name>
         <ts:transaction>
-            <ts:ethereum function="approve" contract="REP" as="bool">
+            <ethereum:call function="approve" contract="REP" as="bool">
                 <ts:data>
                     <ts:address>0x158079ee67fce2f58472a96584a73c7ab9ac95c1</ts:address>
                     <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -69,11 +70,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="mint" contract="cREP" as="uint">
+            <ethereum:call function="mint" contract="cREP" as="uint">
                 <ts:data>
                     <ts:uint256 ref="mintAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -94,11 +95,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="redeem" contract="cREP" as="uint">
+            <ethereum:call function="redeem" contract="cREP" as="uint">
                 <ts:data>
                     <ts:uint256 ref="redeemAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -111,12 +112,12 @@
 
     <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
         <ts:origins>
-            <ts:ethereum function="allowance" contract="REP" as="uint">
+            <ethereum:call function="allowance" contract="REP" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                     <ts:address>0x158079ee67fce2f58472a96584a73c7ab9ac95c1</ts:address>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -127,11 +128,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="REP" as="uint">
+            <ethereum:call function="balanceOf" contract="REP" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -141,8 +142,8 @@
             <ts:string xml:lang="en">Exchange Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="exchangeRateCurrent" contract="cREP" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="exchangeRateCurrent" contract="cREP" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -152,11 +153,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="cREP" as="uint">
+            <ethereum:call function="balanceOf" contract="cREP" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -165,8 +166,8 @@
             <ts:string xml:lang="en">Supply Interest Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="supplyRatePerBlock" contract="cREP" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="supplyRatePerBlock" contract="cREP" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 

--- a/examples/erc20/Compound/cSAI.xml
+++ b/examples/erc20/Compound/cSAI.xml
@@ -6,6 +6,7 @@
         <!ENTITY enable.en SYSTEM "enable.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -41,12 +42,12 @@
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:name>
             <ts:transaction>
-                <ts:ethereum function="approve" contract="SAI" as="bool">
+                <ethereum:call function="approve" contract="SAI" as="bool">
                     <ts:data>
                         <ts:address>0xF5DCe57282A584D2746FaF1593d3121Fcac444dC</ts:address>
                         <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -69,11 +70,11 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="mint" contract="cSAI" as="uint">
+                <ethereum:call function="mint" contract="cSAI" as="uint">
                     <ts:data>
                         <ts:uint256 ref="mintAmount"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -94,11 +95,11 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="redeem" contract="cSAI" as="uint">
+                <ethereum:call function="redeem" contract="cSAI" as="uint">
                     <ts:data>
                         <ts:uint256 ref="redeemAmount"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -112,12 +113,12 @@
 
         <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
             <ts:origins>
-                <ts:ethereum function="allowance" contract="SAI" as="uint">
+                <ethereum:call function="allowance" contract="SAI" as="uint">
                     <ts:data>
                         <ts:address ref="ownerAddress"/>
                         <ts:address>0xF5DCe57282A584D2746FaF1593d3121Fcac444dC</ts:address>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 
@@ -128,11 +129,11 @@
                 <ts:string xml:lang="zh">餘額</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="balanceOf" contract="SAI" as="uint">
+                <ethereum:call function="balanceOf" contract="SAI" as="uint">
                     <ts:data>
                         <ts:address ref="ownerAddress"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 
@@ -142,8 +143,8 @@
                 <ts:string xml:lang="en">Exchange Rate</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="exchangeRateCurrent" contract="cSAI" as="uint">
-                </ts:ethereum>
+                <ethereum:call function="exchangeRateCurrent" contract="cSAI" as="uint">
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 
@@ -153,11 +154,11 @@
                 <ts:string xml:lang="zh">餘額</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="balanceOf" contract="cSAI" as="uint">
+                <ethereum:call function="balanceOf" contract="cSAI" as="uint">
                     <ts:data>
                         <ts:address ref="ownerAddress"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 
@@ -166,8 +167,8 @@
                 <ts:string xml:lang="en">Supply Interest Rate</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="supplyRatePerBlock" contract="cSAI" as="uint">
-                </ts:ethereum>
+                <ethereum:call function="supplyRatePerBlock" contract="cSAI" as="uint">
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 

--- a/examples/erc20/Compound/cUSDC.xml
+++ b/examples/erc20/Compound/cUSDC.xml
@@ -6,6 +6,7 @@
         <!ENTITY enable.en SYSTEM "enable.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -41,12 +42,12 @@
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:name>
         <ts:transaction>
-            <ts:ethereum function="approve" contract="USDC" as="bool">
+            <ethereum:call function="approve" contract="USDC" as="bool">
                 <ts:data>
                     <ts:address>0x39AA39c021dfbaE8faC545936693aC917d5E7563</ts:address>
                     <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -69,11 +70,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="mint" contract="cUSDC" as="uint">
+            <ethereum:call function="mint" contract="cUSDC" as="uint">
                 <ts:data>
                     <ts:uint256 ref="mintAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -94,11 +95,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="redeem" contract="cETH" as="uint">
+            <ethereum:call function="redeem" contract="cETH" as="uint">
                 <ts:data>
                     <ts:uint256 ref="redeemAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -111,12 +112,12 @@
 
     <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
         <ts:origins>
-            <ts:ethereum function="allowance" contract="USDC" as="uint">
+            <ethereum:call function="allowance" contract="USDC" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                     <ts:address>0x39AA39c021dfbaE8faC545936693aC917d5E7563</ts:address>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -127,11 +128,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="USDC" as="uint">
+            <ethereum:call function="balanceOf" contract="USDC" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -141,8 +142,8 @@
             <ts:string xml:lang="en">Exchange Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="exchangeRateCurrent" contract="cUSDC" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="exchangeRateCurrent" contract="cUSDC" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -152,11 +153,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="cUSDC" as="uint">
+            <ethereum:call function="balanceOf" contract="cUSDC" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -165,8 +166,8 @@
             <ts:string xml:lang="en">Supply Interest Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="supplyRatePerBlock" contract="cUSDC" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="supplyRatePerBlock" contract="cUSDC" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 

--- a/examples/erc20/Compound/cWBTC.xml
+++ b/examples/erc20/Compound/cWBTC.xml
@@ -6,6 +6,7 @@
         <!ENTITY enable.en SYSTEM "enable.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -41,12 +42,12 @@
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:name>
         <ts:transaction>
-            <ts:ethereum function="approve" contract="WBTC" as="bool">
+            <ethereum:call function="approve" contract="WBTC" as="bool">
                 <ts:data>
                     <ts:address>0xC11b1268C1A384e55C48c2391d8d480264A3A7F4</ts:address>
                     <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -69,11 +70,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="mint" contract="cWBTC" as="uint">
+            <ethereum:call function="mint" contract="cWBTC" as="uint">
                 <ts:data>
                     <ts:uint256 ref="mintAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -94,11 +95,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="redeem" contract="cWBTC" as="uint">
+            <ethereum:call function="redeem" contract="cWBTC" as="uint">
                 <ts:data>
                     <ts:uint256 ref="redeemAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -111,12 +112,12 @@
 
     <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
         <ts:origins>
-            <ts:ethereum function="allowance" contract="WBTC" as="uint">
+            <ethereum:call function="allowance" contract="WBTC" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                     <ts:address>0xC11b1268C1A384e55C48c2391d8d480264A3A7F4</ts:address>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -127,11 +128,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="WBTC" as="uint">
+            <ethereum:call function="balanceOf" contract="WBTC" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -141,8 +142,8 @@
             <ts:string xml:lang="en">Exchange Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="exchangeRateCurrent" contract="cWBTC" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="exchangeRateCurrent" contract="cWBTC" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -152,11 +153,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="cWBTC" as="uint">
+            <ethereum:call function="balanceOf" contract="cWBTC" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -165,8 +166,8 @@
             <ts:string xml:lang="en">Supply Interest Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="supplyRatePerBlock" contract="cWBTC" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="supplyRatePerBlock" contract="cWBTC" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 

--- a/examples/erc20/Compound/cZRX.xml
+++ b/examples/erc20/Compound/cZRX.xml
@@ -6,6 +6,7 @@
         <!ENTITY enable.en SYSTEM "enable.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -41,12 +42,12 @@
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:name>
         <ts:transaction>
-            <ts:ethereum function="approve" contract="ZRX" as="bool">
+            <ethereum:call function="approve" contract="ZRX" as="bool">
                 <ts:data>
                     <ts:address>0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407</ts:address>
                     <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -69,11 +70,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="mint" contract="cZRX" as="uint">
+            <ethereum:call function="mint" contract="cZRX" as="uint">
                 <ts:data>
                     <ts:uint256 ref="mintAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -94,11 +95,11 @@
             </ts:origins>
         </ts:attribute-type>
         <ts:transaction>
-            <ts:ethereum function="redeem" contract="cZRX" as="uint">
+            <ethereum:call function="redeem" contract="cZRX" as="uint">
                 <ts:data>
                     <ts:uint256 ref="redeemAmount"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:transaction>
         <ts:view xml:lang="en">
             <xhtml:style type="text/css">&style;</xhtml:style>
@@ -111,12 +112,12 @@
 
     <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
         <ts:origins>
-            <ts:ethereum function="allowance" contract="ZRX" as="uint">
+            <ethereum:call function="allowance" contract="ZRX" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                     <ts:address>0xB3319f5D18Bc0D84dD1b4825Dcde5d5f7266d407</ts:address>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -127,11 +128,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="ZRX" as="uint">
+            <ethereum:call function="balanceOf" contract="ZRX" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -141,8 +142,8 @@
             <ts:string xml:lang="en">Exchange Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="exchangeRateCurrent" contract="cZRX" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="exchangeRateCurrent" contract="cZRX" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -152,11 +153,11 @@
             <ts:string xml:lang="zh">餘額</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="balanceOf" contract="cZRX" as="uint">
+            <ethereum:call function="balanceOf" contract="cZRX" as="uint">
                 <ts:data>
                     <ts:address ref="ownerAddress"/>
                 </ts:data>
-            </ts:ethereum>
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 
@@ -165,8 +166,8 @@
             <ts:string xml:lang="en">Supply Interest Rate</ts:string>
         </ts:name>
         <ts:origins>
-            <ts:ethereum function="supplyRatePerBlock" contract="cZRX" as="uint">
-            </ts:ethereum>
+            <ethereum:call function="supplyRatePerBlock" contract="cZRX" as="uint">
+            </ethereum:call>
         </ts:origins>
     </ts:attribute-type>
 

--- a/examples/erc20/DAI/DAI.xml
+++ b/examples/erc20/DAI/DAI.xml
@@ -5,6 +5,7 @@
     <!ENTITY bestRates.en SYSTEM "../BestRates/bestRates.en.js">
     ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -18,8 +19,7 @@
         <ts:address network="1">0x6b175474e89094c44da98b954eedeac495271d0f</ts:address>
     </ts:contract>
     <ts:origins>
-        <ts:ethereum contract="DAI">
-        </ts:ethereum>
+        <ts:ethereum contract="DAI"/>
     </ts:origins>
     <ts:cards>
         <ts:action>
@@ -38,13 +38,13 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="transfer" contract="DAI">
+                <ethereum:call function="transfer" contract="DAI">
                     <ts:data>
                         <!-- to convert erc20 DAI to native xDAI, transfer to this address -->
                         <ts:address>0x4aa42145Aa6Ebf72e164C9bBC74fbD3788045016</ts:address>
                         <ts:uint256 ref="amount"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -66,11 +66,11 @@
                 <ts:string xml:lang="en">DAI-Balance</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="balanceOf" contract="DAI" as="uint">
+                <ethereum:call function="balanceOf" contract="DAI" as="uint">
                     <ts:data>
                         <ts:address ref="ownerAddress"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/DDEX/pDAI.xml
+++ b/examples/erc20/DDEX/pDAI.xml
@@ -4,6 +4,7 @@
         <!ENTITY guide.en SYSTEM "guide.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
   <ts:origins>
     <!-- Define the contract which holds the token that the user will use -->
-    <ts:ethereum contract="pDAI"> <!-- as above ts:contract name -->
-    </ts:ethereum>
+    <ts:ethereum contract="pDAI"/> <!-- as above ts:contract name -->
   </ts:origins>
 
   <ts:cards>
@@ -38,8 +38,8 @@
     <!-- placeholder for future functions -->
     <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <ts:origins>
-        <ts:ethereum as="utf8" function="symbol">
-        </ts:ethereum>
+        <ethereum:call function="symbol" as="utf8">
+        </ethereum:call>
       </ts:origins>
     </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/DDEX/pETH.xml
+++ b/examples/erc20/DDEX/pETH.xml
@@ -4,6 +4,7 @@
         <!ENTITY guide.en SYSTEM "guide.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
   <ts:origins>
     <!-- Define the contract which holds the token that the user will use -->
-    <ts:ethereum contract="pETH"> <!-- as above ts:contract name -->
-    </ts:ethereum>
+    <ts:ethereum contract="pETH"/> <!-- as above ts:contract name -->
   </ts:origins>
 
   <ts:cards>
@@ -39,8 +39,8 @@
     <!-- placeholder for future functions -->
     <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <ts:origins>
-        <ts:ethereum as="utf8" function="symbol">
-        </ts:ethereum>
+        <ethereum:call function="symbol" as="utf8">
+        </ethereum:call>
       </ts:origins>
     </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/DDEX/pUSDT.xml
+++ b/examples/erc20/DDEX/pUSDT.xml
@@ -4,6 +4,7 @@
         <!ENTITY guide.en SYSTEM "guide.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
   <ts:origins>
     <!-- Define the contract which holds the token that the user will use -->
-    <ts:ethereum contract="pUSDT"> <!-- as above ts:contract name -->
-    </ts:ethereum>
+    <ts:ethereum contract="pUSDT"/> <!-- as above ts:contract name -->
   </ts:origins>
 
   <ts:cards>
@@ -38,8 +38,8 @@
     <!-- placeholder for future functions -->
     <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <ts:origins>
-        <ts:ethereum as="utf8" function="symbol">
-        </ts:ethereum>
+        <ethereum:call function="symbol" as="utf8">
+        </ethereum:call>
       </ts:origins>
     </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/SAI/SAI.xml
+++ b/examples/erc20/SAI/SAI.xml
@@ -7,6 +7,7 @@
     <!ENTITY bestRates.en SYSTEM "../BestRates/bestRates.en.js">
 ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -23,8 +24,7 @@
         <ts:address network="1">0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359</ts:address>
     </ts:contract>
     <ts:origins>
-        <ts:ethereum contract="SAI">
-        </ts:ethereum>
+        <ts:ethereum contract="SAI"/>
     </ts:origins>
     <ts:selection id="enabled" filter="allowance>0">
         <ts:name>
@@ -53,11 +53,11 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="swapSaiToDai" contract="MakerMigration">
+                <ethereum:call function="swapSaiToDai" contract="MakerMigration">
                     <ts:data>
                         <ts:uint256 ref="amount"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -70,12 +70,12 @@
                 <ts:string xml:lang="en">Enable Migration</ts:string>
             </ts:name>
             <ts:transaction>
-                <ts:ethereum function="approve" contract="SAI" as="bool">
+                <ethereum:call function="approve" contract="SAI" as="bool">
                     <ts:data>
                         <ts:address>0xc73e0383F3Aff3215E6f04B0331D58CeCf0Ab849</ts:address>
                         <ts:uint256>115792089237316195423570985008687907853269984665640564039457584007913129639935</ts:uint256>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -106,12 +106,12 @@
     </ts:cards>
         <ts:attribute-type id="allowance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
             <ts:origins>
-                <ts:ethereum function="allowance" contract="SAI" as="uint">
+                <ethereum:call function="allowance" contract="SAI" as="uint">
                     <ts:data>
                         <ts:address ref="ownerAddress"/>
                         <ts:address>0xc73e0383f3aff3215e6f04b0331d58cecf0ab849</ts:address>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
         <ts:attribute-type id="balance" syntax="1.3.6.1.4.1.1466.115.121.1.36">
@@ -119,11 +119,11 @@
                 <ts:string xml:lang="en">SAI-Balance</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="balanceOf" contract="SAI" as="uint">
+                <ethereum:call function="balanceOf" contract="SAI" as="uint">
                     <ts:data>
                         <ts:address ref="ownerAddress"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/USDC/USDC.xml
+++ b/examples/erc20/USDC/USDC.xml
@@ -4,6 +4,7 @@
     <!ENTITY bestRates.en SYSTEM "../BestRates/bestRates.en.js">
 ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -17,8 +18,7 @@
         <ts:address network="1">0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48</ts:address>
     </ts:contract>
     <ts:origins>
-        <ts:ethereum contract="USDC">
-        </ts:ethereum>
+        <ts:ethereum contract="USDC"/>
     </ts:origins>
     <ts:cards>
         <ts:action>
@@ -36,11 +36,11 @@
                 <ts:string xml:lang="en">USDC-Balance</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="balanceOf" contract="USDC" as="uint">
+                <ethereum:call function="balanceOf" contract="USDC" as="uint">
                     <ts:data>
                         <ts:address ref="ownerAddress"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/Uniswap/daiPool.xml
+++ b/examples/erc20/Uniswap/daiPool.xml
@@ -4,6 +4,7 @@
         <!ENTITY about.en SYSTEM "about.en.shtml">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="uniswap"> <!-- as above ts:contract name -->
-        </ts:ethereum>
+        <ts:ethereum contract="uniswap"/> <!-- as above ts:contract name -->
     </ts:origins>
 
     <ts:cards>
@@ -37,8 +37,8 @@
         <!-- placeholder for future functions -->
         <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
             <ts:origins>
-                <ts:ethereum as="utf8" function="symbol">
-                </ts:ethereum>
+                <ethereum:call function="symbol" as="utf8">
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/Uniswap/saiPool.xml
+++ b/examples/erc20/Uniswap/saiPool.xml
@@ -4,6 +4,7 @@
         <!ENTITY about.en SYSTEM "about.en.shtml">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="uniswap"> <!-- as above ts:contract name -->
-        </ts:ethereum>
+        <ts:ethereum contract="uniswap"/> <!-- as above ts:contract name -->
     </ts:origins>
 
     <ts:cards>
@@ -37,8 +37,8 @@
         <!-- placeholder for future functions -->
         <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
             <ts:origins>
-                <ts:ethereum as="utf8" function="symbol">
-                </ts:ethereum>
+                <ethereum:call function="symbol" as="utf8">
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/Uniswap/sethPool.xml
+++ b/examples/erc20/Uniswap/sethPool.xml
@@ -4,6 +4,7 @@
         <!ENTITY about.en SYSTEM "about.en.shtml">
 ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="uniswap"> <!-- as above ts:contract name -->
-        </ts:ethereum>
+        <ts:ethereum contract="uniswap"/> <!-- as above ts:contract name -->
     </ts:origins>
 
     <ts:cards>
@@ -37,8 +37,8 @@
         <!-- placeholder for future functions -->
         <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
             <ts:origins>
-                <ts:ethereum as="utf8" function="symbol">
-                </ts:ethereum>
+                <ethereum:call function="symbol" as="utf8">
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/Uniswap/usdcPool.xml
+++ b/examples/erc20/Uniswap/usdcPool.xml
@@ -4,6 +4,7 @@
         <!ENTITY about.en SYSTEM "about.en.shtml">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="uniswap"> <!-- as above ts:contract name -->
-        </ts:ethereum>
+        <ts:ethereum contract="uniswap"/> <!-- as above ts:contract name -->
     </ts:origins>
 
     <ts:cards>
@@ -37,8 +37,8 @@
         <!-- placeholder for future functions -->
         <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
             <ts:origins>
-                <ts:ethereum as="utf8" function="symbol">
-                </ts:ethereum>
+                <ethereum:call function="symbol" as="utf8">
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/Uniswap/wbtcPool.xml
+++ b/examples/erc20/Uniswap/wbtcPool.xml
@@ -4,6 +4,7 @@
         <!ENTITY about.en SYSTEM "about.en.shtml">
 ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="uniswap"> <!-- as above ts:contract name -->
-        </ts:ethereum>
+        <ts:ethereum contract="uniswap"/> <!-- as above ts:contract name -->
     </ts:origins>
 
     <ts:cards>
@@ -37,8 +37,8 @@
         <!-- placeholder for future functions -->
         <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
             <ts:origins>
-                <ts:ethereum as="utf8" function="symbol">
-                </ts:ethereum>
+                <ethereum:call function="symbol" as="utf8">
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/Uniswap/wethPool.xml
+++ b/examples/erc20/Uniswap/wethPool.xml
@@ -4,6 +4,7 @@
         <!ENTITY about.en SYSTEM "about.en.shtml">
 ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="uniswap"> <!-- as above ts:contract name -->
-        </ts:ethereum>
+        <ts:ethereum contract="uniswap"/> <!-- as above ts:contract name -->
     </ts:origins>
 
     <ts:cards>
@@ -37,8 +37,8 @@
         <!-- placeholder for future functions -->
         <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
             <ts:origins>
-                <ts:ethereum as="utf8" function="symbol">
-                </ts:ethereum>
+                <ethereum:call function="symbol" as="utf8">
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/WETH/WETH.xml
+++ b/examples/erc20/WETH/WETH.xml
@@ -6,6 +6,7 @@
     <!ENTITY bestRates.en SYSTEM "../BestRates/bestRates.en.js">
     ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -19,8 +20,7 @@
         <ts:address network="1">0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2</ts:address>
     </ts:contract>
     <ts:origins>
-        <ts:ethereum contract="weth">
-        </ts:ethereum>
+        <ts:ethereum contract="weth"/>
     </ts:origins>
     <ts:cards>
         <ts:action>
@@ -38,9 +38,9 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="deposit" contract="weth">
-                    <ts:value ref="amount"/>
-                </ts:ethereum>
+                <ethereum:call function="deposit" contract="weth">
+                    <ethereum:ether ref="amount"/>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -62,11 +62,11 @@
                 </ts:origins>
             </ts:attribute-type>
             <ts:transaction>
-                <ts:ethereum function="withdraw" contract="weth">
+                <ethereum:call function="withdraw" contract="weth">
                     <ts:data>
                         <ts:uint256 ref="amount"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:transaction>
             <ts:view xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
@@ -88,11 +88,11 @@
                 <ts:string xml:lang="en">WETH-Balance</ts:string>
             </ts:name>
             <ts:origins>
-                <ts:ethereum function="balanceOf" contract="weth" as="uint">
+                <ethereum:call function="balanceOf" contract="weth" as="uint">
                     <ts:data>
                         <ts:address ref="ownerAddress"/>
                     </ts:data>
-                </ts:ethereum>
+                </ethereum:call>
             </ts:origins>
         </ts:attribute-type>
 </ts:token>

--- a/examples/erc20/dForce/USDx.xml
+++ b/examples/erc20/dForce/USDx.xml
@@ -5,6 +5,7 @@
         <!ENTITY moreInfo.en SYSTEM "moreInfo.en.js">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -20,8 +21,7 @@
 
   <ts:origins>
     <!-- Define the contract which holds the token that the user will use -->
-    <ts:ethereum contract="USDx"> <!-- as above ts:contract name -->
-    </ts:ethereum>
+    <ts:ethereum contract="USDx"/> <!-- as above ts:contract name -->
   </ts:origins>
 
   <ts:cards>
@@ -49,8 +49,8 @@
     <!-- placeholder for future functions -->
     <ts:attribute-type id="symbol" syntax="1.3.6.1.4.1.1466.115.121.1.26">
       <ts:origins>
-        <ts:ethereum as="utf8" function="symbol">
-        </ts:ethereum>
+        <ethereum:call function="symbol" as="utf8">
+        </ethereum:call>
       </ts:origins>
     </ts:attribute-type>
 </ts:token>

--- a/examples/fifa/fifa.xml
+++ b/examples/fifa/fifa.xml
@@ -4,6 +4,7 @@
         <!ENTITY style SYSTEM "shared.css">
         ]>
 <ts:token xmlns:ts="http://tokenscript.org/2020/06/tokenscript"
+          xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xhtml="http://www.w3.org/1999/xhtml"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/03/tokenscript.xsd"
@@ -31,8 +32,7 @@
 
     <ts:origins>
         <!-- Define the contract which holds the token that the user will use -->
-        <ts:ethereum contract="FIFA">
-        </ts:ethereum>
+        <ts:ethereum contract="FIFA"/>
     </ts:origins>
 
     <ts:cards>


### PR DESCRIPTION
in all cards, all references to ethereum events and calls are reällocated to the ethereum namespace


detail: http://tokenscript.org/2020/06/tokenscript#ethereum-namespace

this needs to be merged in at the same time as https://github.com/AlphaWallet/TokenScript/pull/346

If you want to test remember to set `TOKENSCRIPT_SCHEMA=` to the one in the ethereum-namespace branch on https://github.com/AlphaWallet/TokenScript

All TS files validate correctly for me.