### PR TITLE
Id and asnx module correction

### DIFF
--- a/examples/ENS/ENS.xml
+++ b/examples/ENS/ENS.xml
@@ -17,6 +17,17 @@
           xmlns:ethereum="urn:ethereum:constantinople"
           custodian="false"
 >
+  <asnx:module name="ENS-Events">
+    <namedType name="NameRegistered">
+      <sequence>
+        <element name="name" ethereum:type="string"/>
+        <element name="label" ethereum:type="bytes32" ethereum:indexed="true"/>
+        <element name="owner" ethereum:type="address" ethereum:indexed="true"/>
+        <element name="cost" ethereum:type="uint"/>
+        <element name="expires" ethereum:type="uint"/>
+      </sequence>
+    </namedType>
+  </asnx:module>
   <ts:label>
     <ts:plurals xml:lang="en">
       <ts:string quantity="one">ENS</ts:string>
@@ -35,15 +46,6 @@
   <!-- emitted via: function registerWithConfig(string memory name, address owner, uint duration, bytes32 secret, address resolver, address addr) public payable -->
   <ts:contract name="ETHRegistrarController">
     <ts:address network="1">0x283af0b28c62c092c9727f1ee09c02ca627eb7f5</ts:address>
-    <asnx:module name="NameRegistered">
-      <sequence>
-        <element name="name" ethereum:type="string"/>
-        <element name="label" ethereum:type="bytes32" ethereum:indexed="true"/>
-        <element name="owner" ethereum:type="address" ethereum:indexed="true"/>
-        <element name="cost" ethereum:type="uint"/>
-        <element name="expires" ethereum:type="uint"/>
-      </sequence>
-    </asnx:module>
   </ts:contract>
   <ts:origins>
     <!-- Define the contract which holds the token that the user will use -->
@@ -146,7 +148,7 @@
   <ts:attribute name="ensName">
       <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.15</ts:syntax></ts:type>
     <ts:origins>
-      <ethereum:event module="NameRegistered" filter="label=${tokenId}" select="name"/>
+      <ethereum:event type="NameRegistered" contract="ETHRegistrarController" filter="label=${tokenId}" select="name"/>
     </ts:origins>
   </ts:attribute>
 

--- a/examples/EntryToken/EntryToken.xml
+++ b/examples/EntryToken/EntryToken.xml
@@ -36,7 +36,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     <!-- Define the contract which holds the token that the user will use -->
     <ts:ethereum contract="EntryToken"/>
   </ts:origins>
-    <ts:selection id="expired" filter="expired=TRUE">
+    <ts:selection name="expired" filter="expired=TRUE">
       <ts:label>
         <ts:plurals xml:lang="en">
           <ts:string quantity="one">Expired Ticket</ts:string>

--- a/examples/action/XDAI-bridge.xml
+++ b/examples/action/XDAI-bridge.xml
@@ -51,7 +51,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          design being that it is inside <token>. With this, it isn't
          apparent that the filters are applicable to the input token:
 
-        <ts:selection id="low_balance" filter="!(balance>1000000000)">
+        <ts:selection name="low_balance" filter="!(balance>1000000000)">
             <ts:denial>
                 <ts:string xml:lang="en">Not enough balance.</ts:string>
             </ts:denial>

--- a/examples/erc20/AAVE/aDAI.xml
+++ b/examples/erc20/AAVE/aDAI.xml
@@ -30,12 +30,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         <ts:ethereum contract="aDAI"/>
     </ts:origins>
 
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cBAT.xml
+++ b/examples/erc20/Compound/cBAT.xml
@@ -25,12 +25,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 <ts:origins>
     <ts:ethereum contract="cBAT"/>
 </ts:origins>
-<ts:selection id="enabled" filter="allowance>0">
+<ts:selection name="enabled" filter="allowance>0">
     <ts:label>
         <ts:string xml:lang="en">contract already enabled</ts:string>
     </ts:label>
 </ts:selection>
-<ts:selection id="notEnabled" filter="allowance=0">
+<ts:selection name="notEnabled" filter="allowance=0">
     <ts:label>
         <ts:string xml:lang="en">contract not enabled</ts:string>
     </ts:label>

--- a/examples/erc20/Compound/cDAI.xml
+++ b/examples/erc20/Compound/cDAI.xml
@@ -25,12 +25,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     <ts:origins>
         <ts:ethereum contract="cDAI"/>
     </ts:origins>
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cREP.xml
+++ b/examples/erc20/Compound/cREP.xml
@@ -25,12 +25,12 @@
 <ts:origins>
     <ts:ethereum contract="cREP"/>
 </ts:origins>
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cSAI.xml
+++ b/examples/erc20/Compound/cSAI.xml
@@ -25,12 +25,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     <ts:origins>
         <ts:ethereum contract="cSAI"/>
     </ts:origins>
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cUSDC.xml
+++ b/examples/erc20/Compound/cUSDC.xml
@@ -25,12 +25,12 @@
 <ts:origins>
     <ts:ethereum contract="cUSDC"/>
 </ts:origins>
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cWBTC.xml
+++ b/examples/erc20/Compound/cWBTC.xml
@@ -25,12 +25,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 <ts:origins>
     <ts:ethereum contract="cWBTC"/>
 </ts:origins>
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cZRX.xml
+++ b/examples/erc20/Compound/cZRX.xml
@@ -25,12 +25,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 <ts:origins>
     <ts:ethereum contract="cZRX"/>
 </ts:origins>
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/DeFiMoneyMarket/mDAI.xml
+++ b/examples/erc20/DeFiMoneyMarket/mDAI.xml
@@ -29,12 +29,12 @@
         <ts:ethereum contract="mDAI"/>
     </ts:origins>
 
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/DeFiMoneyMarket/mUSDC.xml
+++ b/examples/erc20/DeFiMoneyMarket/mUSDC.xml
@@ -29,12 +29,12 @@
         <ts:ethereum contract="mUSDC"/>
     </ts:origins>
 
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/NEST/NEST.xml
+++ b/examples/erc20/NEST/NEST.xml
@@ -36,13 +36,13 @@
         <ts:ethereum contract="NEST"/>
     </ts:origins>
 
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
 
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>

--- a/examples/erc20/SAI/SAI.xml
+++ b/examples/erc20/SAI/SAI.xml
@@ -26,12 +26,12 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     <ts:origins>
         <ts:ethereum contract="SAI"/>
     </ts:origins>
-    <ts:selection id="enabled" filter="allowance>0">
+    <ts:selection name="enabled" filter="allowance>0">
         <ts:label>
             <ts:string xml:lang="en">contract already enabled</ts:string>
         </ts:label>
     </ts:selection>
-    <ts:selection id="notEnabled" filter="allowance=0">
+    <ts:selection name="notEnabled" filter="allowance=0">
         <ts:label>
             <ts:string xml:lang="en">contract not enabled</ts:string>
         </ts:label>


### PR DESCRIPTION
https://github.com/AlphaWallet/TokenScript/pull/359

1. `<selection id=` becomes `<selection name=`
2. ASN modules usage corrected to align with RFC4912.

All pass the validation if you check against the schema in https://github.com/AlphaWallet/TokenScript/pull/359
