### PR TITLE
Improve DeFi UX

### DIFF
--- a/examples/erc20/Compound/cBAT.xml
+++ b/examples/erc20/Compound/cBAT.xml
@@ -57,7 +57,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 
     <ts:card type="action" exclude="notEnabled">
         <ts:label>
-            <ts:string xml:lang="en">Supply</ts:string>
+            <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
         <ts:attribute name="mintAmount">
             <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/Compound/cDAI.xml
+++ b/examples/erc20/Compound/cDAI.xml
@@ -57,7 +57,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 
         <ts:card type="action" exclude="notEnabled">
             <ts:label>
-                <ts:string xml:lang="en">Supply</ts:string>
+                <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
             <ts:attribute name="mintAmount">
                 <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/Compound/cETH.xml
+++ b/examples/erc20/Compound/cETH.xml
@@ -25,7 +25,7 @@
 <ts:cards>
     <ts:card type="action">
         <ts:label>
-            <ts:string xml:lang="en">Supply</ts:string>
+            <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
         <ts:attribute name="mintAmount">
             <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/Compound/cREP.xml
+++ b/examples/erc20/Compound/cREP.xml
@@ -57,7 +57,7 @@
 
     <ts:card type="action" exclude="notEnabled">
         <ts:label>
-            <ts:string xml:lang="en">Supply</ts:string>
+            <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
         <ts:attribute name="mintAmount">
             <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/Compound/cSAI.xml
+++ b/examples/erc20/Compound/cSAI.xml
@@ -57,7 +57,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 
         <ts:card type="action" exclude="notEnabled">
             <ts:label>
-                <ts:string xml:lang="en">Supply</ts:string>
+                <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
             <ts:attribute name="mintAmount">
                 <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/Compound/cUSDC.xml
+++ b/examples/erc20/Compound/cUSDC.xml
@@ -57,7 +57,7 @@
 
         <ts:card type="action" exclude="notEnabled">
             <ts:label>
-                <ts:string xml:lang="en">Supply</ts:string>
+                <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
             <ts:attribute name="mintAmount">
                 <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/Compound/cWBTC.xml
+++ b/examples/erc20/Compound/cWBTC.xml
@@ -57,7 +57,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 
     <ts:card type="action" exclude="notEnabled">
         <ts:label>
-            <ts:string xml:lang="en">Supply</ts:string>
+            <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
         <ts:attribute name="mintAmount">
             <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/Compound/cZRX.xml
+++ b/examples/erc20/Compound/cZRX.xml
@@ -57,7 +57,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 
     <ts:card type="action" exclude="notEnabled">
         <ts:label>
-            <ts:string xml:lang="en">Supply</ts:string>
+            <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
         <ts:attribute name="mintAmount">
             <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/Compound/supply.en.js
+++ b/examples/erc20/Compound/supply.en.js
@@ -16,8 +16,8 @@ class Token {
     render() {
         const decimals18 = 1e+18;
         const decimals8 = 1e+8; //cToken decimals
-        let cTokenBalance = (this.props.cTokenBalance / decimals8).toFixed(2);
-        let tokenBalance = (this.props.tokenBalance / decimals18).toFixed(2);
+        let cTokenBalance = Math.floor((this.props.cTokenBalance / decimals8) * 100) / 100;
+        let tokenBalance = Math.floor((this.props.tokenBalance / decimals18) * 100) / 100;
         let interestRatePerBlock = this.props.supplyInterestRate;
         const averageBlocksPerYear = 2102400;
         let APR = (((interestRatePerBlock * averageBlocksPerYear) / decimals18) * 100).toFixed(2);
@@ -31,8 +31,8 @@ class Token {
             <span><bold><h3>1 ${this.props.underlyingToken} = ${this.props.rate} ${this.props.label}</h3></bold></span>
           </div>
           <div id="inputBox">
-              <bold><h3>Supply ${this.props.underlyingToken} to Compound</h3></bold>
-              <span><input id="mintAmount" type="number"></span>
+              <bold><h3>Deposit ${this.props.underlyingToken} to Compound</h3></bold>
+              <span><input id="mintAmount" type="number" placeholder="deposit up to ${tokenBalance} ${this.props.underlyingToken}"></span>
           </div>
         </div>
 `;

--- a/examples/erc20/Compound/withdraw.en.js
+++ b/examples/erc20/Compound/withdraw.en.js
@@ -16,10 +16,11 @@ class Token {
     render() {
         const decimals18 = 1e+18;
         const decimals8 = 1e+8; //cToken decimals
-        let cTokenBalance = (this.props.cTokenBalance / decimals8).toFixed(2);
-        let tokenBalance = (this.props.tokenBalance / decimals18).toFixed(2);
+        let cTokenBalance = Math.floor((this.props.cTokenBalance / decimals8) * 100) / 100;
+        let tokenBalance = Math.floor((this.props.tokenBalance / decimals18 * 100)) / 100;
         let interestRatePerBlock = this.props.supplyInterestRate;
         const averageBlocksPerYear = 2102400;
+        const withdrawable = Math.floor((cTokenBalance / this.props.rate) * 100) / 100;
         let APR = (((interestRatePerBlock * averageBlocksPerYear) / decimals18) * 100).toFixed(2);
         return`
         <div class="ui container">
@@ -31,8 +32,8 @@ class Token {
             <span><bold><h3>1 ${this.props.underlyingToken} = ${this.props.rate} ${this.props.label}</h3></bold></span>
           </div>
           <div id="inputBox">
-              <bold><h3>Withdraw ${this.props.label} for ${this.props.underlyingToken} from Compound</h3></bold>
-              <span><input id="redeemAmount" type="number"></span>
+              <bold><h3>Withdraw ${this.props.underlyingToken} from Compound</h3></bold>
+              <span><input id="redeemAmount" type="number" placeholder="withdraw up to ${withdrawable} ${this.props.underlyingToken}"></span>
           </div>
         </div>`;
     }

--- a/examples/erc20/DeFiMoneyMarket/mDAI.xml
+++ b/examples/erc20/DeFiMoneyMarket/mDAI.xml
@@ -62,7 +62,7 @@
 
         <ts:card type="action" exclude="notEnabled">
             <ts:label>
-                <ts:string xml:lang="en">Supply</ts:string>
+                <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
             <ts:attribute name="mintAmount">
                 <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/DeFiMoneyMarket/mETH.xml
+++ b/examples/erc20/DeFiMoneyMarket/mETH.xml
@@ -29,7 +29,7 @@
     <ts:cards>
         <ts:card type="action">
             <ts:label>
-                <ts:string xml:lang="en">Supply</ts:string>
+                <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
             <ts:attribute name="mintAmount">
                 <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>

--- a/examples/erc20/DeFiMoneyMarket/mUSDC.xml
+++ b/examples/erc20/DeFiMoneyMarket/mUSDC.xml
@@ -63,7 +63,7 @@
 
         <ts:card type="action" exclude="notEnabled">
             <ts:label>
-                <ts:string xml:lang="en">Supply</ts:string>
+                <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
             <ts:attribute name="mintAmount">
                 <ts:type><ts:syntax>1.3.6.1.4.1.1466.115.121.1.36</ts:syntax></ts:type>


### PR DESCRIPTION
This PR:
- adds a placeholder to let you know how much you can deposit and withdraw
- Rounds down the numbers 
- Changes supply action name to deposit

TODO:
- Check the borrow amount against the withdrawable and then show only what you can withdraw
- Get the native balance in the card for cETH and other TokenScripts that depend on native balances 