### PR TITLE
Require name for action cards

### DIFF
--- a/examples/ENS/ENS.xml
+++ b/examples/ENS/ENS.xml
@@ -56,7 +56,7 @@
   </ts:origins>
 
   <ts:cards>
-    <ts:card type="token">
+    <ts:card type="token" name="main">
       <ts:item-view xml:lang="en">
         <xhtml:style type="text/css">&item-view-style;</xhtml:style>
         <xhtml:script type="text/javascript">&item-view.en;</xhtml:script>

--- a/examples/ENS/ENS.xml
+++ b/examples/ENS/ENS.xml
@@ -67,7 +67,7 @@
       </ts:view>
     </ts:card>
 
-    <ts:card type="action">
+    <ts:card type="action" name="records">
       <ts:label>
         <ts:string xml:lang="en">Records</ts:string>
       </ts:label>
@@ -111,7 +111,7 @@
 
     </ts:card>
 
-    <ts:card type="action">
+    <ts:card type="action" name="renew">
       <ts:label>
         <ts:string xml:lang="en">Renew</ts:string>
       </ts:label>

--- a/examples/EntryToken/EntryToken.xml
+++ b/examples/EntryToken/EntryToken.xml
@@ -46,7 +46,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       </ts:label>
     </ts:selection>
   <ts:cards>
-    <ts:card type="token">
+    <ts:card type="token" name="main">
       <ts:item-view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
         <style type="text/css">&style;</style>
         <body>&icon.en;</body>

--- a/examples/EntryToken/EntryToken.xml
+++ b/examples/EntryToken/EntryToken.xml
@@ -56,7 +56,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         <script type="text/javascript">&token.en;</script>
       </ts:view>
     </ts:card>
-    <ts:card type="action" exclude="expired">
+    <ts:card type="action" exclude="expired" name="enter">
       <!-- this action is of the model confirm-back.
       It should be <ts:card type="action" model="confirm-back"> but Weiwu
       shied away from specifying that due to the likely change of design causing an upgrade path issue.

--- a/examples/Karma/karma.xml
+++ b/examples/Karma/karma.xml
@@ -48,7 +48,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             </ts:view>
         </ts:card>
 
-        <ts:card type="action">
+        <ts:card type="action" name="start">
             <ts:label>
                 <ts:string xml:lang="en">Start</ts:string>
                 <ts:string xml:lang="zh">开车</ts:string>
@@ -59,7 +59,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 <body>&start.en;</body>
             </ts:view>
         </ts:card>
-        <ts:card type="action">
+        <ts:card type="action" name="attest">
             <ts:label>
                 <ts:string xml:lang="en">Attestations</ts:string>
                 <ts:string xml:lang="zh">认证</ts:string>
@@ -70,7 +70,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 <body>&attestations.en;</body>
             </ts:view>
         </ts:card>
-        <ts:card type="action">
+        <ts:card type="action" name="market">
             <ts:label>
                 <ts:string xml:lang="en">Market</ts:string>
                 <ts:string xml:lang="zh">市场</ts:string>

--- a/examples/Karma/karma.xml
+++ b/examples/Karma/karma.xml
@@ -37,7 +37,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         <ts:ethereum contract="CarToken"/>
     </ts:origins>
     <ts:cards>
-        <ts:card type="token">
+        <ts:card type="token" name="main">
             <ts:item-view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
                 <style type="text/css">&style;</style>
                 <body>&item-view.en;</body>

--- a/examples/UEFA/UEFA.xml
+++ b/examples/UEFA/UEFA.xml
@@ -35,7 +35,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="token">
+        <ts:card type="token" name="main">
             <ts:item-view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
                 <script type="text/javascript">&UEFA.en;</script>

--- a/examples/action/XDAI-bridge.xml
+++ b/examples/action/XDAI-bridge.xml
@@ -7,8 +7,8 @@
           xmlns:ethereum="urn:ethereum:constantinople"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xsi:schemaLocation="http://tokenscript.org/2020/06/tokenscript http://tokenscript.org/2020/06/tokenscript.xsd"
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xmlns:asnx="urn:ietf:params:xml:ns:asnx"
+          name="convert-to-DAI"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 >
     <ts:label>
         <ts:string xml:lang="en">Convert to DAI</ts:string>

--- a/examples/edcon/unicon.xml
+++ b/examples/edcon/unicon.xml
@@ -28,7 +28,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="token">
+        <ts:card type="token" name="main">
             <ts:item-view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
                 <script type="text/javascript">&unicon.en;</script>

--- a/examples/erc20/AAVE/aDAI.xml
+++ b/examples/erc20/AAVE/aDAI.xml
@@ -42,7 +42,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:selection>
 
     <ts:cards>
-        <ts:card type="action" exclude="enabled">
+        <ts:card type="action" exclude="enabled" name="enable">
             <ts:label>
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:label>
@@ -87,7 +87,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         <!--            <ts:view xml:lang="en">&supply.en;</ts:view>-->
         <!--        </ts:card>-->
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="redeem">
             <ts:label>
                 <ts:string xml:lang="en">Redeem</ts:string>
             </ts:label>

--- a/examples/erc20/COMP/COMP.xml
+++ b/examples/erc20/COMP/COMP.xml
@@ -29,7 +29,7 @@
         <ts:ethereum contract="COMP"/>
     </ts:origins>
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="about">
             <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
             </ts:label>
@@ -39,7 +39,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action">
+        <ts:card type="action" name="claim">
             <ts:label>
                 <ts:string xml:lang="en">Claim COMP</ts:string>
             </ts:label>
@@ -56,7 +56,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action">
+        <ts:card type="action" name="deligate">
             <ts:label>
                 <ts:string xml:lang="en">Delegate Vote</ts:string>
             </ts:label>

--- a/examples/erc20/Compound/cBAT.xml
+++ b/examples/erc20/Compound/cBAT.xml
@@ -37,7 +37,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 </ts:selection>
 <ts:cards>
     <!-- Do not show this card if the token contract is already enabled -->
-    <ts:card type="action" exclude="enabled">
+    <ts:card type="action" exclude="enabled" name="enable">
         <ts:label>
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:label>
@@ -55,7 +55,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         </ts:view>
     </ts:card>
 
-    <ts:card type="action" exclude="notEnabled">
+    <ts:card type="action" exclude="notEnabled" name="deposit">
         <ts:label>
             <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
@@ -83,7 +83,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         </ts:view>
     </ts:card>
 
-    <ts:card type="action">
+    <ts:card type="action" name="withdraw">
         <ts:label>
             <ts:string xml:lang="en">Withdraw</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cDAI.xml
+++ b/examples/erc20/Compound/cDAI.xml
@@ -37,7 +37,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:selection>
     <ts:cards>
         <!-- Do not show this card if the token contract is already enabled -->
-        <ts:card type="action" exclude="enabled">
+        <ts:card type="action" exclude="enabled" name="enable">
             <ts:label>
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:label>
@@ -55,7 +55,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="deposit">
             <ts:label>
                 <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
@@ -83,7 +83,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="withdraw">
             <ts:label>
                 <ts:string xml:lang="en">Withdraw</ts:string>
             </ts:label>

--- a/examples/erc20/Compound/cETH.xml
+++ b/examples/erc20/Compound/cETH.xml
@@ -23,7 +23,7 @@
 </ts:origins>
 
 <ts:cards>
-    <ts:card type="action">
+    <ts:card type="action" name="deposit">
         <ts:label>
             <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
@@ -51,7 +51,7 @@
         </ts:view>
     </ts:card>
 
-    <ts:card type="action">
+    <ts:card type="action" name="withdraw">
         <ts:label>
             <ts:string xml:lang="en">Withdraw</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cREP.xml
+++ b/examples/erc20/Compound/cREP.xml
@@ -37,7 +37,7 @@
     </ts:selection>
     <ts:cards>
         <!-- Do not show this card if the token contract is already enabled -->
-    <ts:card type="action" exclude="enabled">
+    <ts:card type="action" exclude="enabled" name="enable">
         <ts:label>
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:label>
@@ -55,7 +55,7 @@
         </ts:view>
     </ts:card>
 
-    <ts:card type="action" exclude="notEnabled">
+    <ts:card type="action" exclude="notEnabled" name="deposit">
         <ts:label>
             <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
@@ -83,7 +83,7 @@
         </ts:view>
     </ts:card>
 
-    <ts:card type="action" exclude="notEnabled">
+    <ts:card type="action" exclude="notEnabled" name="withdraw">
         <ts:label>
             <ts:string xml:lang="en">Withdraw</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cSAI.xml
+++ b/examples/erc20/Compound/cSAI.xml
@@ -37,7 +37,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:selection>
     <ts:cards>
         <!-- Do not show this card if the token contract is already enabled -->
-        <ts:card type="action" exclude="enabled">
+        <ts:card type="action" exclude="enabled" name="enable">
             <ts:label>
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:label>
@@ -55,7 +55,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="deposit">
             <ts:label>
                 <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
@@ -83,7 +83,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="withdraw">
             <ts:label>
                 <ts:string xml:lang="en">Withdraw</ts:string>
             </ts:label>

--- a/examples/erc20/Compound/cUSDC.xml
+++ b/examples/erc20/Compound/cUSDC.xml
@@ -37,7 +37,7 @@
     </ts:selection>
     <ts:cards>
         <!-- Do not show this card if the token contract is already enabled -->
-        <ts:card type="action" exclude="enabled">
+        <ts:card type="action" exclude="enabled" name="enable">
             <ts:label>
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:label>
@@ -55,7 +55,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="deposit">
             <ts:label>
                 <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
@@ -83,7 +83,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="withdraw">
             <ts:label>
                 <ts:string xml:lang="en">Withdraw</ts:string>
             </ts:label>

--- a/examples/erc20/Compound/cWBTC.xml
+++ b/examples/erc20/Compound/cWBTC.xml
@@ -37,7 +37,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:selection>
 <ts:cards>
     <!-- Do not show this card if the token contract is already enabled -->
-    <ts:card type="action" exclude="enabled">
+    <ts:card type="action" exclude="enabled" name="enable">
         <ts:label>
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:label>
@@ -55,7 +55,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         </ts:view>
     </ts:card>
 
-    <ts:card type="action" exclude="notEnabled">
+    <ts:card type="action" exclude="notEnabled" name="deposit">
         <ts:label>
             <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
@@ -83,7 +83,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         </ts:view>
     </ts:card>
 
-    <ts:card type="action" exclude="notEnabled">
+    <ts:card type="action" exclude="notEnabled" name="withdraw">
         <ts:label>
             <ts:string xml:lang="en">Withdraw</ts:string>
         </ts:label>

--- a/examples/erc20/Compound/cZRX.xml
+++ b/examples/erc20/Compound/cZRX.xml
@@ -37,7 +37,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:selection>
 <ts:cards>
     <!-- Do not show this card if the token contract is already enabled -->
-    <ts:card type="action" exclude="enabled">
+    <ts:card type="action" exclude="enabled" name="enable">
         <ts:label>
             <ts:string xml:lang="en">Enable</ts:string>
         </ts:label>
@@ -55,7 +55,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         </ts:view>
     </ts:card>
 
-    <ts:card type="action" exclude="notEnabled">
+    <ts:card type="action" exclude="notEnabled" name="deposit">
         <ts:label>
             <ts:string xml:lang="en">Deposit</ts:string>
         </ts:label>
@@ -83,7 +83,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         </ts:view>
     </ts:card>
 
-    <ts:card type="action" exclude="notEnabled">
+    <ts:card type="action" exclude="notEnabled" name="withdraw">
         <ts:label>
             <ts:string xml:lang="en">Withdraw</ts:string>
         </ts:label>

--- a/examples/erc20/DAI/DAI.xml
+++ b/examples/erc20/DAI/DAI.xml
@@ -22,7 +22,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         <ts:ethereum contract="DAI"/>
     </ts:origins>
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="convert-to-xdAI">
             <ts:label>
                 <ts:string xml:lang="en">Convert to xDAI</ts:string>
             </ts:label>
@@ -52,7 +52,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 <xhtml:script type="text/javascript">&DAI-bridge.en;</xhtml:script>
             </ts:view>
         </ts:card>
-        <ts:card type="action">
+        <ts:card type="action" name="best-rates">
             <ts:label>
                 <ts:string xml:lang="en">Best Rates</ts:string>
             </ts:label>

--- a/examples/erc20/DDEX/pDAI.xml
+++ b/examples/erc20/DDEX/pDAI.xml
@@ -24,7 +24,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   </ts:origins>
 
   <ts:cards>
-    <ts:card type="action">
+    <ts:card type="action" name="guide">
       <ts:label>
         <ts:string xml:lang="en">Guide</ts:string>
       </ts:label>

--- a/examples/erc20/DDEX/pETH.xml
+++ b/examples/erc20/DDEX/pETH.xml
@@ -25,7 +25,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 
   <ts:cards>
 
-    <ts:card type="action">
+    <ts:card type="action" name="guide">
       <ts:label>
         <ts:string xml:lang="en">Guide</ts:string>
       </ts:label>

--- a/examples/erc20/DDEX/pUSDT.xml
+++ b/examples/erc20/DDEX/pUSDT.xml
@@ -24,7 +24,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   </ts:origins>
 
   <ts:cards>
-    <ts:card type="action">
+    <ts:card type="action" name="guide">
       <ts:label>
         <ts:string xml:lang="en">Guide</ts:string>
       </ts:label>

--- a/examples/erc20/DeFiMoneyMarket/mDAI.xml
+++ b/examples/erc20/DeFiMoneyMarket/mDAI.xml
@@ -42,7 +42,7 @@
 
     <ts:cards>
 
-        <ts:card type="action" exclude="enabled">
+        <ts:card type="action" exclude="enabled" name="enable">
             <ts:label>
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:label>
@@ -60,7 +60,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="deposit">
             <ts:label>
                 <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
@@ -88,7 +88,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="withdraw">
             <ts:label>
                 <ts:string xml:lang="en">Withdraw</ts:string>
             </ts:label>

--- a/examples/erc20/DeFiMoneyMarket/mETH.xml
+++ b/examples/erc20/DeFiMoneyMarket/mETH.xml
@@ -27,7 +27,7 @@
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="deposit">
             <ts:label>
                 <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
@@ -53,7 +53,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action">
+        <ts:card type="action" name="withdraw">
             <ts:label>
                 <ts:string xml:lang="en">Withdraw</ts:string>
             </ts:label>

--- a/examples/erc20/DeFiMoneyMarket/mUSDC.xml
+++ b/examples/erc20/DeFiMoneyMarket/mUSDC.xml
@@ -42,7 +42,7 @@
 
     <ts:cards>
 
-        <ts:card type="action" exclude="enabled">
+        <ts:card type="action" exclude="enabled" name="enable">
             <ts:label>
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:label>
@@ -61,7 +61,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="deposit">
             <ts:label>
                 <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
@@ -88,7 +88,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="withdraw">
             <ts:label>
                 <ts:string xml:lang="en">Withdraw</ts:string>
             </ts:label>

--- a/examples/erc20/NEST/NEST.xml
+++ b/examples/erc20/NEST/NEST.xml
@@ -46,7 +46,7 @@
     </ts:selection>
 
     <ts:cards>
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="deposit">
             <ts:label>
                 <ts:string xml:lang="en">Deposit</ts:string>
             </ts:label>
@@ -75,7 +75,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="notEnabled">
+        <ts:card type="action" exclude="notEnabled" name="withdraw">
             <ts:label>
                 <ts:string xml:lang="en">Withdraw</ts:string>
             </ts:label>
@@ -104,7 +104,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action">
+        <ts:card type="action" name="dividend">
             <ts:label>
                 <ts:string xml:lang="en">Dividend</ts:string>
             </ts:label>
@@ -118,7 +118,7 @@
             </ts:view>
         </ts:card>
 
-        <ts:card type="action" exclude="enabled">
+        <ts:card type="action" exclude="enabled" name="enable">
             <ts:label>
                 <ts:string xml:lang="en">Enable</ts:string>
             </ts:label>

--- a/examples/erc20/SAI/SAI.xml
+++ b/examples/erc20/SAI/SAI.xml
@@ -21,7 +21,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         <ts:ethereum contract="SAI"/>
     </ts:origins>
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="guide">
             <ts:label>
                 <ts:string xml:lang="en">Important!</ts:string>
             </ts:label>

--- a/examples/erc20/USDC/USDC.xml
+++ b/examples/erc20/USDC/USDC.xml
@@ -21,7 +21,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         <ts:ethereum contract="USDC"/>
     </ts:origins>
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="best-rates">
             <ts:label>
                 <ts:string xml:lang="en">Best Rates</ts:string>
             </ts:label>

--- a/examples/erc20/Uniswap/daiPool.xml
+++ b/examples/erc20/Uniswap/daiPool.xml
@@ -24,7 +24,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="about">
             <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
             </ts:label>

--- a/examples/erc20/Uniswap/saiPool.xml
+++ b/examples/erc20/Uniswap/saiPool.xml
@@ -24,7 +24,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="about">
             <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
             </ts:label>

--- a/examples/erc20/Uniswap/sethPool.xml
+++ b/examples/erc20/Uniswap/sethPool.xml
@@ -24,7 +24,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="about">
             <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
             </ts:label>

--- a/examples/erc20/Uniswap/usdcPool.xml
+++ b/examples/erc20/Uniswap/usdcPool.xml
@@ -24,7 +24,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="about">
             <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
             </ts:label>

--- a/examples/erc20/Uniswap/wbtcPool.xml
+++ b/examples/erc20/Uniswap/wbtcPool.xml
@@ -24,7 +24,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="about">
             <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
             </ts:label>

--- a/examples/erc20/Uniswap/wethPool.xml
+++ b/examples/erc20/Uniswap/wethPool.xml
@@ -24,7 +24,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="about">
             <ts:label>
                 <ts:string xml:lang="en">About</ts:string>
             </ts:label>

--- a/examples/erc20/WETH/WETH.xml
+++ b/examples/erc20/WETH/WETH.xml
@@ -23,7 +23,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         <ts:ethereum contract="weth"/>
     </ts:origins>
     <ts:cards>
-        <ts:card type="action">
+        <ts:card type="action" name="wrap">
             <ts:label>
                 <ts:string xml:lang="en">Wrap</ts:string>
             </ts:label>
@@ -48,7 +48,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 <xhtml:script type="text/javascript">&wrap.en;</xhtml:script>
             </ts:view>
         </ts:card>
-        <ts:card type="action">
+        <ts:card type="action" name="unwrap">
             <ts:label>
                 <ts:string xml:lang="en">Unwrap</ts:string>
             </ts:label>
@@ -75,7 +75,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 <xhtml:script type="text/javascript">&unwrap.en;</xhtml:script>
             </ts:view>
         </ts:card>
-        <ts:card type="action">
+        <ts:card type="action" name="best-rate">
             <ts:label>
                 <ts:string xml:lang="en">Best Rates</ts:string>
             </ts:label>

--- a/examples/erc20/dForce/USDx.xml
+++ b/examples/erc20/dForce/USDx.xml
@@ -25,7 +25,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   </ts:origins>
 
   <ts:cards>
-    <ts:card type="action">
+    <ts:card type="action" name="guide">
       <ts:label>
         <ts:string xml:lang="en">Guide</ts:string>
       </ts:label>
@@ -35,7 +35,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       </ts:view>
     </ts:card>
 
-    <ts:card type="action">
+    <ts:card type="action" name="more-info">
       <ts:label>
         <ts:string xml:lang="en">More info</ts:string>
       </ts:label>

--- a/examples/fifa/fifa.xml
+++ b/examples/fifa/fifa.xml
@@ -36,7 +36,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     </ts:origins>
 
     <ts:cards>
-        <ts:card type="token">
+        <ts:card type="token" name="main">
             <ts:item-view xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
                 <xhtml:style type="text/css">&style;</xhtml:style>
                 <script type="text/javascript">&fifa.en;</script>


### PR DESCRIPTION
Rational:

https://community.tokenscript.org/t/cards-name/406

No change needed in iOS/Android to make this work, so this one can be merged without waiting for a supportive release.

Merge this together with the other https://github.com/AlphaWallet/TokenScript/pull/376